### PR TITLE
Reset settings

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,7 +6,7 @@
 See '[config.js](./config.js)' for available configurations. <br />
 `modName`: Name of the mod. (duh) <br />
 `defaultBuildDir`: Destination for 'built' addon files. <br /> 
-`sourceFiles`: Provides the list of files to be deployed. New files that should be included with the addon should be added to the list. <br />
+`sourceFiles`: Provides the list of files to be deployed. New files that should be included with the addon need to be added to the list. <br />
 `esoAddonDir`: Specifies where to deploy game files. It looks to see if the `ESO_ADDON_DIR` environment variable is set.
 
 # Available commands

--- a/deploy/config.js
+++ b/deploy/config.js
@@ -12,7 +12,8 @@ const addonConfig = {
     'Bindings.xml',
     'header.lua',
     'TeamFormation.lua',
-    'TeamFormation.xml'
+    'TeamFormation.xml',
+    'ProvisionsTeamFormation.txt'
   ]
 };
 

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "build": "grunt clean:build && grunt copy:build",
-    "deploy": "grunt clean:deploy && grunt copy:deploy"
+    "deploy": "grunt clean:deploy && grunt copy:deploy",
+    "build-deploy": "yarn run build && yarn run deploy"
   },
   "devDependencies": {
     "grunt": "^1.0.3",

--- a/function/LAM2Panel.lua
+++ b/function/LAM2Panel.lua
@@ -19,6 +19,30 @@ local function TeamFormation_mapJRULES()
 	return TeamFormation_mapChoices(colorizePseudo, ProvTF.vars.jRules)
 end
 
+local function TeamFormation_reset()
+	ProvTF.vars = {}
+	ProvTF.vars.enabled = ProvTF.defaults.enabled
+	ProvTF.vars.posx = ProvTF.defaults.posx
+	ProvTF.vars.posy = ProvTF.defaults.posy
+	ProvTF.vars.width =ProvTF.defaults.width
+	ProvTF.vars.height = ProvTF.defaults.height
+	ProvTF.vars.refreshRate = ProvTF.defaults.refreshRate
+	ProvTF.vars.circle =ProvTF.defaults.circle
+	ProvTF.vars.camRotation = ProvTF.defaults.camRotation
+	ProvTF.vars.scale = ProvTF.defaults.scale
+	ProvTF.vars.logdist = ProvTF.defaults.logdist
+	ProvTF.vars.cardinal = ProvTF.defaults.cardinal
+	ProvTF.vars.siege = ProvTF.defaults.siege
+	ProvTF.vars.myAlpha =ProvTF.defaults.myAlpha
+	ProvTF.vars.roleIcon = ProvTF.defaults.roleIcon
+	-- Don't pass default's jRules reference.
+	ProvTF.vars.jRules = {}
+	
+	ProvTF.UI:SetAnchor(CENTER, GuiRoot, CENTER, ProvTF.vars.posx, ProvTF.vars.posy)
+	TeamFormation_SetHidden(not ProvTF.vars.enabled)
+	TeamFormation_ResetRefreshRate()
+end
+
 function TeamFormation_createLAM2Panel()
 	local panelData =
 	{
@@ -30,17 +54,7 @@ function TeamFormation_createLAM2Panel()
 		slashCommand = "/tf",
 		registerForRefresh = true,
 		registerForDefaults = true,
-		resetFunc = function()
-			ProvTF.vars = nil
-			ProvTF.vars = ProvTF.defaults
-			ProvTF.vars.jRules = nil
-			ProvTF.vars.jRules = {}
-
-			ProvTF.UI:SetAnchor(CENTER, GuiRoot, CENTER, ProvTF.vars.posx, ProvTF.vars.posy)
-			TeamFormation_SetHidden(not ProvTF.vars.enabled)
-
-			TeamFormation_ResetRefreshRate()
-		end,
+		resetFunc = TeamFormation_reset,
 	}
 
 	local optionsData =

--- a/function/LAM2Panel.lua
+++ b/function/LAM2Panel.lua
@@ -24,7 +24,7 @@ local function TeamFormation_reset()
 	ProvTF.vars.enabled = ProvTF.defaults.enabled
 	ProvTF.vars.posx = ProvTF.defaults.posx
 	ProvTF.vars.posy = ProvTF.defaults.posy
-	ProvTF.vars.width =ProvTF.defaults.width
+	ProvTF.vars.width = ProvTF.defaults.width
 	ProvTF.vars.height = ProvTF.defaults.height
 	ProvTF.vars.refreshRate = ProvTF.defaults.refreshRate
 	ProvTF.vars.circle =ProvTF.defaults.circle

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -23,7 +23,7 @@ ZO_CreateStringId("SI_TF_SETTING_WIDTH_TOOLTIP", "Change the Width of TeamFormat
 ZO_CreateStringId("SI_TF_SETTING_HEIGHT", "Height")
 ZO_CreateStringId("SI_TF_SETTING_HEIGHT_TOOLTIP", "Change the Height of TeamFormation.")
 ZO_CreateStringId("SI_TF_SETTING_LOCK", "Lock Position")
-ZO_CreateStringId("SI_TF_SETTING_LOCK_TOOLTIP", "Lock TeamFormation position, make it unmovable.")
+ZO_CreateStringId("SI_TF_SETTING_LOCK_TOOLTIP", "Lock TeamFormation position, make it immovable.")
 
 ZO_CreateStringId("SI_TF_SETTING_FOCUSOPTIONS", "TeamFormation screen")
 ZO_CreateStringId("SI_TF_SETTING_FOCUSOPTIONS_TOOLTIP", "Configure the UI of TeamFormation.")
@@ -42,7 +42,7 @@ ZO_CreateStringId("SI_TF_SETTING_SCALE_TOOLTIP", "Change the scale of pins.")
 ZO_CreateStringId("SI_TF_SETTING_LOGDIST", "Distance logarithmic")
 ZO_CreateStringId("SI_TF_SETTING_LOGDIST_TOOLTIP", "0 = Linear\nAdjusts the maximum pin distance.")
 ZO_CreateStringId("SI_TF_SETTING_CARDINAL", "Opacity of the cardinal points")
-ZO_CreateStringId("SI_TF_SETTING_CARDINAL_TOOLTIP", "0 = Hidden\Adjusts the transparency of the four cardinal points (North, South, East, & West).")
+ZO_CreateStringId("SI_TF_SETTING_CARDINAL_TOOLTIP", "0 = Hidden\nAdjusts the transparency of the four cardinal points (North, South, East, & West).")
 ZO_CreateStringId("SI_TF_SETTING_SIEGE", "Show UI when at siege weapon")
 ZO_CreateStringId("SI_TF_SETTING_SIEGE_TOOLTIP", "Show TeamFormation when you use siege weapon.")
 
@@ -53,10 +53,10 @@ ZO_CreateStringId("SI_TF_SETTING_YOURALPHA_TOOLTIP", "0 = Hidden\nChanges the tr
 ZO_CreateStringId("SI_TF_SETTING_ROLE", "Role icon")
 ZO_CreateStringId("SI_TF_SETTING_ROLE_TOOLTIP", "Show role icon instead of class icon.")
 
-ZO_CreateStringId("SI_TF_SETTING_HRADDON", "[NEW] Customize icon color with following parameters.");
+ZO_CreateStringId("SI_TF_SETTING_HRADDON", "[NEW] Customize icon color with the following settings.");
 
 ZO_CreateStringId("SI_TF_SETTING_COLOROPTIONS", "Color customization")
-ZO_CreateStringId("SI_TF_SETTING_COLOROPTIONS_TOOLTIP", "Customize the color for the icons displayed in the TeamFormation.")
+ZO_CreateStringId("SI_TF_SETTING_COLOROPTIONS_TOOLTIP", "Customize the color for the icons displayed in TeamFormation.")
 ZO_CreateStringId("SI_TF_SETTING_COLORRESET", "Reset")
 ZO_CreateStringId("SI_TF_SETTING_COLORRESET_TOOLTIP", "Reset the player and class color.")
 ZO_CreateStringId("SI_TF_SETTING_JRULES", "Based on player name")


### PR DESCRIPTION
No longer passes the reference of `ProvTF.defaults` to `ProvTF.vars`. This causes the reset settings to only work once. After a reset, any changes made in the settings menu were being written to `ProvTF.defaults`. For now I just set every setting manually.

Also included a few miscellaneous updates to the English strings and the deploy files.